### PR TITLE
Add Acumatica manual sync, sync logs, undo and audit logging

### DIFF
--- a/src/actions/integrations/acumatica/connection.ts
+++ b/src/actions/integrations/acumatica/connection.ts
@@ -315,7 +315,7 @@ export async function saveAcumaticaConnection(
         apiVersion: input.apiVersion,
         companyId: input.companyId,
         encryptedCredentials,
-        status: 'INACTIVE', // Not active until fully configured
+        status: 'ACTIVE',
         lastConnectionTest: new Date(),
         // Set default date range (last 30 days to now)
         invoiceStartDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
@@ -325,6 +325,7 @@ export async function saveAcumaticaConnection(
         apiVersion: input.apiVersion,
         companyId: input.companyId,
         encryptedCredentials,
+        status: 'ACTIVE',
         lastConnectionTest: new Date(),
         connectionErrorMessage: null,
       },

--- a/src/app/dashboard/audit-logs/client-page.tsx
+++ b/src/app/dashboard/audit-logs/client-page.tsx
@@ -94,6 +94,8 @@ const ACTION_LABELS: Record<string, string> = {
   user_role_changed: 'Role Changed',
   user_removed: 'User Removed',
   settings_updated: 'Settings Updated',
+  integration_sync: 'Integration Sync',
+  integration_sync_reverted: 'Integration Sync Reverted',
 }
 
 const ENTITY_TYPE_LABELS: Record<string, string> = {
@@ -105,6 +107,7 @@ const ENTITY_TYPE_LABELS: Record<string, string> = {
   project: 'Project',
   organization: 'Organization',
   settings: 'Settings',
+  integration: 'Integration',
 }
 
 export default function AuditLogsClient() {

--- a/src/app/dashboard/integrations/acumatica/setup/page.tsx
+++ b/src/app/dashboard/integrations/acumatica/setup/page.tsx
@@ -34,6 +34,7 @@ export default function AcumaticaSetupPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
   const [formData, setFormData] = useState({
     instanceUrl: '',
     apiVersion: '24.200.001',
@@ -74,6 +75,7 @@ export default function AcumaticaSetupPage() {
             username: '', // Don't pre-fill for security
             password: '', // User needs to re-enter to make changes
           });
+          setIsConnected(integration.status === 'ACTIVE');
 
           // Show info that credentials are saved
           if (integration.encryptedCredentials) {
@@ -264,6 +266,15 @@ export default function AcumaticaSetupPage() {
           style={{ width: '16.67%' }}
         />
       </div>
+
+      {isConnected && (
+        <Alert className="border-emerald-500/30 bg-emerald-500/10">
+          <CheckCircle className="h-4 w-4 text-emerald-600" />
+          <AlertDescription className="text-emerald-700 dark:text-emerald-400">
+            Acumatica is connected. Update credentials if needed or continue setup.
+          </AlertDescription>
+        </Alert>
+      )}
 
       {/* Credentials Already Saved Banner */}
       {testResult?.success && !formData.username && !formData.password && (

--- a/src/app/dashboard/integrations/acumatica/sync-logs/page.tsx
+++ b/src/app/dashboard/integrations/acumatica/sync-logs/page.tsx
@@ -1,0 +1,77 @@
+import { requireAdmin } from '@/lib/auth'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import Link from 'next/link'
+import { ArrowLeft, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { getAcumaticaSyncLogs } from '@/actions/integrations/acumatica/sync'
+import { AcumaticaSyncLogsClient } from '@/components/integrations/acumatica-sync-logs-client'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AcumaticaSyncLogsPage() {
+  await requireAdmin()
+
+  const result = await getAcumaticaSyncLogs()
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
+            <Link href="/dashboard/integrations">Integrations</Link>
+            <span>/</span>
+            <Link href="/dashboard/integrations/acumatica/setup">Acumatica</Link>
+            <span>/</span>
+            <span>Sync Logs</span>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-purple-600 via-blue-600 to-purple-600 bg-clip-text text-transparent">
+            Acumatica Sync Logs
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            Review recent sync runs, imported records, and undo a sync if needed.
+          </p>
+        </div>
+        <Link href="/dashboard/integrations">
+          <Button variant="outline" className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Back to Integrations
+          </Button>
+        </Link>
+      </div>
+
+      <Card className="border-purple-500/20">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Recent Sync Activity</CardTitle>
+              <CardDescription>
+                Logs are stored for every manual sync. Use undo to roll back unedited records.
+              </CardDescription>
+            </div>
+            <Link href="/dashboard/integrations">
+              <Button variant="ghost" className="gap-2">
+                <RefreshCw className="h-4 w-4" />
+                Start New Sync
+              </Button>
+            </Link>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {result.success && result.logs?.length ? (
+            <AcumaticaSyncLogsClient logs={result.logs} />
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              {result.success ? 'No sync logs available yet.' : result.error}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -4,8 +4,6 @@ import {
   CheckCircle,
   AlertCircle,
   ExternalLink,
-  Settings,
-  RefreshCw,
   Calendar,
   Database,
   Clock
@@ -22,6 +20,7 @@ import {
 import Link from 'next/link'
 import Image from 'next/image'
 import { getAcumaticaIntegration } from '@/actions/integrations/acumatica/connection'
+import { AcumaticaIntegrationActions } from '@/components/integrations/acumatica-integration-actions'
 
 export const dynamic = 'force-dynamic'
 
@@ -211,20 +210,12 @@ export default async function IntegrationsPage() {
                   </div>
                 </div>
                 <div className="flex gap-2">
-                  {integration.status === 'connected' ? (
-                    <>
-                      <Button variant="outline" size="sm" className="gap-2">
-                        <RefreshCw className="h-4 w-4" />
-                        Sync Now
-                      </Button>
-                      <Button variant="outline" size="sm" className="gap-2">
-                        <Settings className="h-4 w-4" />
-                        Configure
-                      </Button>
-                      <Button variant="destructive" size="sm">
-                        Disconnect
-                      </Button>
-                    </>
+                  {integration.status === 'connected' && integration.id === 'acumatica' ? (
+                    <AcumaticaIntegrationActions setupUrl={integration.setupUrl || '/dashboard/integrations/acumatica/setup'} />
+                  ) : integration.status === 'connected' ? (
+                    <Button variant="outline" size="sm" className="gap-2">
+                      Manage
+                    </Button>
                   ) : integration.comingSoon ? (
                     <Button disabled className="gap-2">
                       <Clock className="h-4 w-4" />

--- a/src/components/integrations/acumatica-integration-actions.tsx
+++ b/src/components/integrations/acumatica-integration-actions.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useTransition } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { RefreshCw, Settings, ListOrdered, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/hooks/use-toast'
+import { syncAcumaticaInvoices } from '@/actions/integrations/acumatica/sync'
+
+interface AcumaticaIntegrationActionsProps {
+  setupUrl: string
+}
+
+export function AcumaticaIntegrationActions({ setupUrl }: AcumaticaIntegrationActionsProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [isPending, startTransition] = useTransition()
+
+  const handleSync = () => {
+    startTransition(async () => {
+      const result = await syncAcumaticaInvoices()
+      if (result.success) {
+        toast({
+          title: 'Sync complete',
+          description: `Created ${result.summary.salesCreated} sales, ${result.summary.clientsCreated} clients, ${result.summary.projectsCreated} projects.`,
+        })
+        router.refresh()
+        return
+      }
+
+      toast({
+        title: 'Sync failed',
+        description: result.error || 'Unable to sync Acumatica data',
+        variant: 'destructive',
+      })
+    })
+  }
+
+  return (
+    <div className="flex gap-2">
+      <Button variant="outline" size="sm" className="gap-2" onClick={handleSync} disabled={isPending}>
+        {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+        {isPending ? 'Syncing' : 'Sync Now'}
+      </Button>
+      <Link href={setupUrl}>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Settings className="h-4 w-4" />
+          Configure
+        </Button>
+      </Link>
+      <Link href="/dashboard/integrations/acumatica/sync-logs">
+        <Button variant="outline" size="sm" className="gap-2">
+          <ListOrdered className="h-4 w-4" />
+          Sync Logs
+        </Button>
+      </Link>
+    </div>
+  )
+}

--- a/src/components/integrations/acumatica-sync-logs-client.tsx
+++ b/src/components/integrations/acumatica-sync-logs-client.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useTransition } from 'react'
+import { format } from 'date-fns'
+import { Loader2, RotateCcw } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import { useToast } from '@/hooks/use-toast'
+import { undoAcumaticaSync } from '@/actions/integrations/acumatica/sync'
+
+interface SyncLogEntry {
+  id: string
+  syncType: string
+  status: string
+  startedAt: string
+  completedAt: string | null
+  triggeredBy: {
+    id: string
+    name: string | null
+    email: string | null
+  } | null
+  invoicesFetched: number
+  invoicesProcessed: number
+  invoicesSkipped: number
+  salesCreated: number
+  clientsCreated: number
+  projectsCreated: number
+  errorsCount: number
+}
+
+interface AcumaticaSyncLogsClientProps {
+  logs: SyncLogEntry[]
+}
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline' | 'success'> = {
+  SUCCESS: 'success',
+  PARTIAL_SUCCESS: 'secondary',
+  FAILED: 'destructive',
+  IN_PROGRESS: 'outline',
+  STARTED: 'outline',
+}
+
+export function AcumaticaSyncLogsClient({ logs }: AcumaticaSyncLogsClientProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  const handleUndo = (logId: string) => {
+    startTransition(async () => {
+      const result = await undoAcumaticaSync(logId)
+      if (result.success) {
+        toast({
+          title: 'Sync reverted',
+          description: `Removed ${result.data.deletedSales} sales, ${result.data.deletedProjects} projects, ${result.data.deletedClients} clients.`,
+        })
+        router.refresh()
+        return
+      }
+
+      toast({
+        title: 'Unable to undo',
+        description: result.error || 'Failed to undo sync',
+        variant: 'destructive',
+      })
+    })
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Started</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Triggered By</TableHead>
+          <TableHead>Processed</TableHead>
+          <TableHead>Created</TableHead>
+          <TableHead>Errors</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {logs.map((log) => {
+          const createdSummary = `${log.salesCreated} sales / ${log.clientsCreated} clients / ${log.projectsCreated} projects`
+          const processedSummary = `${log.invoicesProcessed}/${log.invoicesFetched} invoices`
+          return (
+            <TableRow key={log.id}>
+              <TableCell>
+                <div className="text-sm font-medium">
+                  {format(new Date(log.startedAt), 'PPP p')}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {log.completedAt
+                    ? `Completed ${format(new Date(log.completedAt), 'p')}`
+                    : 'In progress'}
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge variant={STATUS_VARIANT[log.status] || 'outline'}>{log.status}</Badge>
+              </TableCell>
+              <TableCell>
+                <div className="text-sm">
+                  {log.triggeredBy?.name || log.triggeredBy?.email || 'System'}
+                </div>
+                <div className="text-xs text-muted-foreground">{log.syncType}</div>
+              </TableCell>
+              <TableCell className="text-sm">
+                {processedSummary}
+                <div className="text-xs text-muted-foreground">Skipped: {log.invoicesSkipped}</div>
+              </TableCell>
+              <TableCell className="text-sm">{createdSummary}</TableCell>
+              <TableCell className="text-sm">{log.errorsCount}</TableCell>
+              <TableCell className="text-right">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={() => handleUndo(log.id)}
+                  disabled={
+                    isPending ||
+                    (log.salesCreated + log.clientsCreated + log.projectsCreated === 0) ||
+                    !['SUCCESS', 'PARTIAL_SUCCESS'].includes(log.status)
+                  }
+                >
+                  {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCcw className="h-4 w-4" />}
+                  Undo
+                </Button>
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -27,6 +27,9 @@ export type AuditAction =
   | 'user_removed'
   // Settings actions
   | 'settings_updated'
+  // Integration actions
+  | 'integration_sync'
+  | 'integration_sync_reverted'
 
 export type EntityType = 
   | 'commission'
@@ -37,6 +40,7 @@ export type EntityType =
   | 'project'
   | 'organization'
   | 'settings'
+  | 'integration'
 
 export interface CreateAuditLogParams {
   // Who


### PR DESCRIPTION
### Motivation
- Provide a server-side manual sync pipeline to import invoices from Acumatica into the app's clients/projects/sales model.
- Allow admins to trigger a manual sync now and review past sync runs from the UI before adding scheduled syncs later.
- Offer an undo workflow to revert records created by a sync when those records have not been edited.
- Record high-level summaries of sync runs in the audit logs for traceability and compliance.

### Description
- Added a new server action file `src/actions/integrations/acumatica/sync.ts` implementing `syncAcumaticaInvoices`, `getAcumaticaSyncLogs`, and `undoAcumaticaSync` which fetch invoices, create clients/projects/sales, create commission calculations, persist `IntegrationSyncLog` details, and create summary audit logs via `createAuditLog`.
- Added UI components and pages: `src/components/integrations/acumatica-integration-actions.tsx`, `src/components/integrations/acumatica-sync-logs-client.tsx`, and the page `src/app/dashboard/integrations/acumatica/sync-logs/page.tsx`, and wired them into `src/app/dashboard/integrations/page.tsx` and the setup flow `src/app/dashboard/integrations/acumatica/setup/page.tsx` to show connected state and expose sync controls.
- Updated connection save behavior in `src/actions/integrations/acumatica/connection.ts` to mark the integration `status: 'ACTIVE'` on successful save and added audit action types `integration_sync` and `integration_sync_reverted` in `src/lib/audit-log.ts` and labels in the audit logs UI.
- Improved sync robustness and metadata handling by populating `createdBySyncLogId` on created `Client`/`Project`, recording `syncLogId` on `SalesTransaction`, handling line-level vs invoice-level imports, and persisting skip/error details in `IntegrationSyncLog`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69571f866ac88323ac9a11a6491e05ef)