### PR TITLE
Fix Acumatica rawExternalData null handling

### DIFF
--- a/src/actions/integrations/acumatica/sync.ts
+++ b/src/actions/integrations/acumatica/sync.ts
@@ -682,8 +682,8 @@ export async function syncAcumaticaInvoices() {
                 externalQuantity: integration.storeQtyAndPrice ? line.Qty?.value : null,
                 externalUnitPrice: integration.storeQtyAndPrice ? line.UnitPrice?.value : null,
                 rawExternalData: integration.storeQtyAndPrice || integration.storeItemDescription
-                  ? line
-                  : null,
+                  ? (line ?? undefined)
+                  : undefined,
               },
             })
 


### PR DESCRIPTION
### Motivation
- The Vercel build failed with a TypeScript error because `rawExternalData` could be `null`, which is not assignable to the Prisma JSON field type. 
- The change ensures we don't pass `null` into a `Json?` field to satisfy TypeScript and Prisma typings. 
- The intent is to only store `rawExternalData` when the integration is configured to keep line-level data.

### Description
- Updated the `rawExternalData` assignment in `src/actions/integrations/acumatica/sync.ts` to use `(line ?? undefined)` when the condition is true, otherwise `undefined`.
- This replaces the previous `line : null` pattern to avoid passing `null` into the Prisma JSON field.
- No other business logic was modified.

### Testing
- No automated tests were run after this change as part of the rollout.
- Recommend running `npm run test:unit && npm run build` to validate the fix locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695724d5d698832392bf5c33e296936f)