### PR TITLE
Fix Acumatica line raw data serialization for Prisma JSON field

### DIFF
--- a/src/actions/integrations/acumatica/sync.ts
+++ b/src/actions/integrations/acumatica/sync.ts
@@ -17,7 +17,14 @@ import type {
   AcumaticaInvoiceLine,
   InvoiceQueryFilters,
 } from '@/lib/acumatica/types'
-import type { CommissionPlan, CommissionRule, Client, Project, User } from '@prisma/client'
+import type {
+  CommissionPlan,
+  CommissionRule,
+  Client,
+  Project,
+  User,
+  Prisma,
+} from '@prisma/client'
 
 const ACUMATICA_SYSTEM = 'ACUMATICA'
 
@@ -682,7 +689,9 @@ export async function syncAcumaticaInvoices() {
                 externalQuantity: integration.storeQtyAndPrice ? line.Qty?.value : null,
                 externalUnitPrice: integration.storeQtyAndPrice ? line.UnitPrice?.value : null,
                 rawExternalData: integration.storeQtyAndPrice || integration.storeItemDescription
-                  ? (line ?? undefined)
+                  ? line
+                    ? (JSON.parse(JSON.stringify(line)) as Prisma.InputJsonValue)
+                    : undefined
                   : undefined,
               },
             })


### PR DESCRIPTION
### Motivation
- A TypeScript compile error occurred because `AcumaticaInvoiceLine` is not assignable to Prisma JSON input types when stored directly in a JSON field.
- The intent is to ensure `rawExternalData` stored via Prisma matches `Prisma.InputJsonValue` so the project can build cleanly.

### Description
- Import `Prisma` types from `@prisma/client` to allow casting to `Prisma.InputJsonValue`.
- Serialize the Acumatica invoice `line` with `JSON.parse(JSON.stringify(line))` and cast it to `Prisma.InputJsonValue` before assigning to `rawExternalData`.
- Preserve the previous `undefined` behavior when `integration.storeQtyAndPrice` and `integration.storeItemDescription` are not set.
- Change implemented in `src/actions/integrations/acumatica/sync.ts`.

### Testing
- No automated tests were run as part of this change.
- The change is purely type/serialization focused and intended to resolve the prior compile-time type error reported by CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69572a8481e88323b627102472e8bf29)