### PR TITLE
Serialize Acumatica invoice payload to Prisma JSON for rawExternalData

### DIFF
--- a/src/actions/integrations/acumatica/sync.ts
+++ b/src/actions/integrations/acumatica/sync.ts
@@ -757,7 +757,7 @@ export async function syncAcumaticaInvoices() {
               integrationId: integration.id,
               syncLogId: syncLog.id,
               ...baseExternalData,
-              rawExternalData: invoice,
+              rawExternalData: JSON.parse(JSON.stringify(invoice)) as Prisma.InputJsonValue,
             },
           })
 


### PR DESCRIPTION
### Motivation
- Fix a TypeScript compile error where `AcumaticaInvoice` is not assignable to Prisma JSON input when saving `rawExternalData`.
- Ensure invoice-level sync behavior matches the already serialized line-level `rawExternalData` handling to avoid runtime/type issues.
- Resolve Vercel build failures caused by incorrect typing of the `rawExternalData` field.

### Description
- Update `src/actions/integrations/acumatica/sync.ts` to cast the invoice payload with `JSON.parse(JSON.stringify(invoice)) as Prisma.InputJsonValue` when setting `rawExternalData`.
- This replaces the direct assignment of `invoice` to `rawExternalData` and aligns serialization with the line-level branch.
- No other functional changes were made to the sync logic.

### Testing
- No automated tests were run as part of this change.
- CI/build should be re-run to verify that the TypeScript error and Vercel deployment issue are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957308b2ad883238f790c09d2ae3e24)